### PR TITLE
README.mdへのDB設計の記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,38 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# ChatSpace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups,  through:  :users_groups
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group|string|null: false|
+### Association
+- has_many :messages
+- has_many :users,  through: :users_groups
+
+## users_groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null :false, foreign_key: true|
+|group_id|integer|null :false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null :false|
+|user_id|integer|null :false, foreign_key: true|
+|group_id|integer|null :false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user|string|null: false|
-|email|string|null: false|
+|user|string|null: false, index: user|
+|email|string|null: false, unique: true|
 |password|string|null: false|
 ### Association
 - has_many :messages
@@ -54,7 +54,8 @@ Things you may want to cover:
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null :false|
+|body|text|null :false|
+|image|string|null :false|
 |user_id|integer|null :false, foreign_key: true|
 |group_id|integer|null :false, foreign_key: true|
 ### Association

--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ Things you may want to cover:
 |text|text|null :false|
 |user_id|integer|null :false, foreign_key: true|
 |group_id|integer|null :false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -27,19 +27,21 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user|string|null: false, index: user|
+|name|string|null: false, index: true|
 |email|string|null: false, unique: true|
 |password|string|null: false|
 ### Association
 - has_many :messages
+- has_many :users_groups
 - has_many :groups,  through:  :users_groups
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group|string|null: false|
+|name|string|null: false, unique: true|
 ### Association
 - has_many :messages
+- has_many :users_groups
 - has_many :users,  through: :users_groups
 
 ## users_groupsテーブル
@@ -54,8 +56,8 @@ Things you may want to cover:
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null :false|
-|image|string|null :false|
+|body|text||
+|image|string||
 |user_id|integer|null :false, foreign_key: true|
 |group_id|integer|null :false, foreign_key: true|
 ### Association


### PR DESCRIPTION
# What
README.mdにDB設計を記述した。対象となるテーブルは「usersテーブル」「groupsテーブル」「users_groupsテーブル」「messagesテーブル」の4つ。「users_groupsテーブル」は中間テーブルとして作成。

# Why
DB仕様の文書化のため。