### PR TITLE
ChatSpaceメッセージ送信の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,4 @@ gem 'pry-rails'
 
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -294,6 +298,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,3 +1,15 @@
 $(function() {
-  console.log("jQueryを導入した")
+  $('.new-message').on('submit', function(e){
+    e.preventDefault();
+    let formData = new FormData(this);
+    let url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      data Type: 'json'
+      processData: false,
+      contentType: false
+    })
+  });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,3 @@
+$(function() {
+  console.log("jQueryを導入した")
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,45 @@
-$(function() {
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      let html = 
+      `<div class="messages">
+        <div class="messages__box">
+          <p class="messages__box__username">
+            ${message.user_name}
+          </p>
+          <p class="messages__box__date">
+            ${message.created_at}
+          </p>
+        </div>
+      <div class="message">
+        <p class="message__content">
+          ${message.content}
+        </p>
+        <img class="message__image" src="${message.image_url}">
+      </div>
+    </div>`
+    return html;
+    } else {
+      let html =
+      `<div class="messages">
+        <div class="messages__box">
+          <p class="messages__box__username">
+            ${message.user_name}
+          </p>
+          <p class="messages__box__date">
+            ${message.created_at}
+          </p>
+        </div>
+        <div class="message">
+          <p class="message__content">
+            ${message.content}
+          </p>
+        </div>
+      </div>`
+      return html;
+    };
+  }
+
   $('.new-message').on('submit', function(e){
     e.preventDefault();
     let formData = new FormData(this);
@@ -10,6 +51,16 @@ $(function() {
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data);
+      $('.main-messages').append(html);
+      $('.main-messages').animate({ scrollTop: $('.main-messages')[0].scrollHeight});
+      $('.submit-btn').prop("disabled", false);
+      $('.new-message')[0].reset();
+    })
+    .fail(function(){
+      alert("メッセージ送信に失敗しました");
     })
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -7,7 +7,7 @@ $(function() {
       url: url,
       type: "POST",
       data: formData,
-      data Type: 'json'
+      dataType: 'json',
       processData: false,
       contentType: false
     })

--- a/app/assets/stylesheets/_chat-main.scss
+++ b/app/assets/stylesheets/_chat-main.scss
@@ -59,11 +59,6 @@
           height: 300px;
         }
       }
-      // &__comment {
-      //   margin-top: 12px;
-      //   color: #434A54;
-      //   font-size: 14px;
-      // }
     }
   }
   .main-footer {

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module ChatSpace
   class Application < Rails::Application
     config.load_defaults 6.0
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# What
ChatSpaceに非同期通信を実装する。

1. 新しいブランチの作成(ajax-function)
2. jQueryの導入とJavaScriptの準備
3. jsファイルの作成とjQueryの読み込み
4. フォーム送信時のイベント発火
5. イベント発火時のAjaxを使用したmessages#createに関わる設定
6. メッセージの保存とrespond_toによるHTMLとJSONの処理の分割
7. jbuilderの記述
8. JSONのdoneメソッドでの受取りとHTML作成
9. 作成したHTMLのメッセージ画面一番下への追加
10. メッセージ送信時のメッセージ画面の最下部へのスクロール
11. 送信ボタンの連続実行の実装
12. 非同期に失敗時のアラート出力
13. 表示日時の日本時間への変更

# Why
非同期通信を使ってメッセージの送信を非同期で行えるようにする。

# Gyazo gif
https://gyazo.com/ce0d5955cc88713499ae0be2ba71103e